### PR TITLE
Fix chrome failure

### DIFF
--- a/jquery.simulate.js
+++ b/jquery.simulate.js
@@ -114,7 +114,7 @@ $.extend( $.simulate.prototype, {
 			// IE 9+ creates events with pageX and pageY set to 0.
 			// Trying to modify the properties throws an error,
 			// so we define getters to return the correct values.
-			if ( Object.getOwnPropertyDescriptor && Object.getOwnPropertyDescriptor( event, "pageX" ).configurable && Object.defineProperty ) {
+			if ( Object.getOwnPropertyDescriptor && Object.getOwnPropertyDescriptor( event, "pageX" ) && Object.getOwnPropertyDescriptor( event, "pageX" ).configurable && Object.defineProperty ) {
 				configurable = true;
 			}
 			if ( event.pageX === 0 && event.pageY === 0 && configurable ) {


### PR DESCRIPTION
Chrome puts the pageX/Y getters on the parent UIEvent instead of the MouseEvent, so it blows up unless you add this additional check.
